### PR TITLE
error message param changed as message_detail

### DIFF
--- a/src/Api/Error.php
+++ b/src/Api/Error.php
@@ -22,8 +22,8 @@ class Error
      */
     public function getText()
     {
-        if (isset($this->errorData['message'])) {
-            return $this->errorData['message'];
+        if (isset($this->errorData['message_detail'])) {
+            return $this->errorData['message_detail'];
         }
 
         if (isset($this->errorData['code'])) {


### PR DESCRIPTION
The package throws meaningless generic exception messages. Due to #492 issue created by me. On most of actions, we need to see more clear error messages.