### PR TITLE
search scope changed on pinner search

### DIFF
--- a/src/Api/Providers/Pinners.php
+++ b/src/Api/Providers/Pinners.php
@@ -24,7 +24,7 @@ class Pinners extends FollowableProvider
         'following',
     ];
 
-    protected $searchScope  = 'people';
+    protected $searchScope  = 'users';
     protected $entityIdName = 'user_id';
     protected $followersFor = 'username';
 


### PR DESCRIPTION
As I mentioned on #498 issue, pinterest changed their requests. On the pinners->search function we were sent search scope parameter as people before. It changed as users instead of people. @seregazhuk could you please validate the code.